### PR TITLE
экранируем пароль

### DIFF
--- a/lib/Common/Helpers/OpenSSL.php
+++ b/lib/Common/Helpers/OpenSSL.php
@@ -54,7 +54,7 @@ class OpenSSL
     {
         $cmd     = 'openssl smime -sign -signer ' . $keychain->getPublicCert()
             . ' -inkey ' . $keychain->getPrivateKey()
-            . ' -passin pass:' . $keychain->getKeyPassword()
+            . ' -passin pass:\'' . $keychain->getKeyPassword() . '\''
             . ' -nochain -nocerts -outform PEM -nodetach';
 
         return self::executeCMD($cmd, $data);


### PR DESCRIPTION
иначе

`openssl smime -sign -signer /path/to/cert.cer -inkey /path/to/private.key -passin pass:12(34 -nochain -nocerts -outform PEM -nodetach`

-bash: syntax error near unexpected token `('